### PR TITLE
Fixes nkXRSystem.GetSessionFeatures

### DIFF
--- a/Wasm.XR/wwwroot/js/XR.8.0.4.js
+++ b/Wasm.XR/wwwroot/js/XR.8.0.4.js
@@ -62,7 +62,7 @@ window.nkXRSystem =
         var features = [];
 
         var ls = (fs >>  0) & 1;
-        var fs = (fs >>  1) & 1;
+        var lf = (fs >>  1) & 1;
         var ub = (fs >>  2) & 1;
         var bf = (fs >>  3) & 1;
         var vr = (fs >>  4) & 1;
@@ -78,7 +78,7 @@ window.nkXRSystem =
 
         if (ls == 1)
             features.push('local');
-        if (fs == 1)
+        if (lf == 1)
             features.push('local-floor');
         if (ub == 1)
             features.push('unbounded');


### PR DESCRIPTION
The variable `fs` is declared twice, once as the function parameter and again for the local-floor feature. This blocks other features after this line from being set.

After fixing this and enabling the `hand-tracking` feature, it is now possible to see the JS hand joints object in the  `nkXRInputSource` by adding `is.hand`:
![image](https://github.com/user-attachments/assets/d10c8c2c-ecdf-4f76-8474-71a06dcd004c)