### PR TITLE
Amends Window.OnKeyDownDelegate key value

### DIFF
--- a/Wasm.Dom/wwwroot/js/Window.8.0.5.js
+++ b/Wasm.Dom/wwwroot/js/Window.8.0.5.js
@@ -182,10 +182,27 @@
                 event.deltaX, event.deltaY, event.deltaZ,  event.deltaMode);
         });
 
-        window.addEventListener('keydown', (event) =>
-        {
+        window.addEventListener('keydown', (event) => {
+            var char;
+            switch (event.key) {
+                case "Enter":
+                    char = 13;
+                    break;
+                case "Backspace":
+                    char = 8;
+                    break;
+                case "Tab":
+                    char = 9;
+                    break;
+                case "Delete":
+                    char = 127;
+                    break;
+                default:
+                    char = (event.key.length == 1) ? event.key.charCodeAt(0) : 0;
+                    break;
+            }
             DotNet.invokeMethod('nkast.Wasm.Dom', 'JsWindowOnKeyDown', uid,
-                event.key.charCodeAt(0), event.keyCode, event.location);
+                char, event.keyCode, event.location);
         });
         window.addEventListener('keyup', (event) =>
         {


### PR DESCRIPTION
Amends the char value from the window keydown event, which is passed along by the `OnKeyDownDelegate`. In turn KNI uses this value for text entry code and these changes allow KNI desktop platforms existing behaviors to be matched.

From the Wasm side this is done by:
- Only providing a key value for the following:
 1 ) Single character key events.
 2 ) Control key characters within the lower ASCII range.
- Preventing other function keys being truncated to a single character (for example `Shift` should not return `S`).
- Where a key value should not be passed, the null character `'\0'` is sent instead.