### PR TITLE
Adds DOMRect and Element.GetBoundingClientRect

### DIFF
--- a/Wasm.Dom/Dom/DOMRect.cs
+++ b/Wasm.Dom/Dom/DOMRect.cs
@@ -1,0 +1,14 @@
+﻿namespace nkast.Wasm.Dom
+{
+    public struct DOMRect
+    {
+        public double X;
+        public double Y;
+        public double Width;
+        public double Height;
+        public double Top { get { return Y; } }
+        public double Right { get { return X + Width; } }
+        public double Bottom { get { return Y + Height; } }
+        public double Left { get { return X; } }
+    }
+}

--- a/Wasm.Dom/Dom/Element.cs
+++ b/Wasm.Dom/Dom/Element.cs
@@ -8,6 +8,16 @@ namespace nkast.Wasm.Dom
     public abstract class Element<TElement> : CachedJSObject<TElement>
         where TElement : JSObject
     {
+        public int ClientLeft
+        {
+            get { return InvokeRetInt("nkElement.GetClientLeft"); }
+        }
+
+        public int ClientTop
+        {
+            get { return InvokeRetInt("nkElement.GetClientTop"); }
+        }
+
         public int ClientWidth
         {
             get { return InvokeRetInt("nkElement.GetClientWidth"); }
@@ -20,6 +30,13 @@ namespace nkast.Wasm.Dom
 
         protected Element(int uid) : base(uid)
         {
+        }
+
+        public unsafe DOMRect GetBoundingClientRect()
+        {
+            DOMRect result = default;
+            Invoke<IntPtr>("nkElement.GetBoundingClientRect", new IntPtr(&result));
+            return result;
         }
 
         protected override void Dispose(bool disposing)

--- a/Wasm.Dom/wwwroot/js/Document.8.0.11.js
+++ b/Wasm.Dom/wwwroot/js/Document.8.0.11.js
@@ -27,6 +27,16 @@
 
 window.nkElement =
 {
+    GetClientLeft: function (uid)
+    {
+        var e = nkJSObject.GetObject(uid);
+        return e.clientLeft;
+    },
+    GetClientTop: function (uid)
+    {
+        var e = nkJSObject.GetObject(uid);
+        return e.clientTop;
+    },
     GetClientWidth: function(uid)
     {
         var e = nkJSObject.GetObject(uid);
@@ -36,6 +46,16 @@ window.nkElement =
     {
         var e = nkJSObject.GetObject(uid);
         return e.clientHeight;
+    },
+    GetBoundingClientRect: function (uid, d)
+    {
+        var e = nkJSObject.GetObject(uid);
+        var pt = Module.HEAP32[(d + 0) >> 2];
+        var r = e.getBoundingClientRect();
+        Module.HEAPF64[(pt + 0) >> 3] = r.x;
+        Module.HEAPF64[(pt + 8) >> 3] = r.y;
+        Module.HEAPF64[(pt + 16) >> 3] = r.width;
+        Module.HEAPF64[(pt + 24) >> 3] = r.height;
     },
 };
 


### PR DESCRIPTION
Adds DOMRect struct and Element.GetBoundingClientRect method.
<https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect>

Unlike `ClientLeft` & `ClientTop`, which give the relative pixel distances between connected elements, `GetBoundingClientRect` gives the absolute viewport position of the element.

This is intended to be used in a subsequent Kni PR to implement the `Window.ClientBounds` position for when the canvas holder is at a non origin location.