### PR TITLE
Adds nkJSObject.DotNetVersionFixups for dotnet 10.0

### DIFF
--- a/Wasm.JSInterop/wwwroot/js/JSObject.8.0.11.js
+++ b/Wasm.JSInterop/wwwroot/js/JSObject.8.0.11.js
@@ -158,6 +158,37 @@
         let func = nkJSObject.funcMap[fid];
         return func(uid, d);
     },
+
+    DotNetVersionFixups: function ()
+    {
+        if (globalThis.Module === undefined)
+            globalThis.Module = Blazor.runtime.Module;
+
+        if (globalThis.BINDING === undefined)
+        {
+            globalThis.BINDING =
+            {
+                conv_string: function (pt)
+                {
+                    var len = Module.HEAP32[(pt + 8) >> 2];
+                    var str = nkJSObject.ToJSString(pt + 12, len);
+                    return str;
+                }
+            };
+        }
+
+        if (Blazor.platform.getArrayLength === undefined)
+        {
+            Object.assign(Blazor.platform,
+                {
+                    getArrayLength: function (arr)
+                    {
+                        var arrPtr = Blazor.platform.getArrayEntryPtr(arr, 0, 4);
+                        return Module.HEAP32[(arrPtr - 4) >> 2];
+                    }
+                });
+        }
+    },
 }
 
 window.nkJSArray =


### PR DESCRIPTION
Adds a nkJSObject.DotNetVersionFixups function to apply dotnet 10.0 fixups.

Calling this function allows `net10.0` to be added as a target framework for the nkast.Wasm projects and Kni.BlazorGL. It does so by adding back the removed `Module`, `BINDING.conv_string` and `Blazor.platform.getArrayLength` definitions, but only if they are missing. This means no changes will occur to the original implementations when using `net8.0`.

In the case of Kni, adding `window.nkJSObject.DotNetVersionFixups();` at the beginning of the existing `window.initRenderJS` function in `index.html` will ensure the fixups are in place at startup. I have added this to `nkJSObject` as this serves as a base object for most things, however this could be moved to another location if preferred.

Associated Kni GitHub discussion post:
https://github.com/kniEngine/kni/discussions/2541