### PR TITLE
Implement WebAudio methods for timing

### DIFF
--- a/Wasm.Audio/Audio/AudioBuffer.cs
+++ b/Wasm.Audio/Audio/AudioBuffer.cs
@@ -22,6 +22,11 @@ namespace nkast.Wasm.Audio
             get { return InvokeRetInt("nkAudioBuffer.GetLength"); }
         }
 
+        public double Duration
+        {
+            get { return InvokeRetDouble("nkAudioBuffer.GetDuration"); }
+        }
+
         public int NumberOfChannels
         {
             get { return InvokeRetInt("nkAudioBuffer.GetNumberOfChannels"); }

--- a/Wasm.Audio/Audio/AudioBufferSourceNode.cs
+++ b/Wasm.Audio/Audio/AudioBufferSourceNode.cs
@@ -37,6 +37,11 @@ namespace nkast.Wasm.Audio
             }
         }
 
+        public void Start(double when = 0d, double offset = 0d, double duration = 0d)
+        {
+            Invoke("nkAudioBufferSourceNode.Start", when, offset, duration);
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (disposing)

--- a/Wasm.Audio/Audio/BaseAudioContext.cs
+++ b/Wasm.Audio/Audio/BaseAudioContext.cs
@@ -22,6 +22,15 @@ namespace nkast.Wasm.Audio
             }
         }
 
+        public double CurrentTime
+        {
+            get
+            {
+                double currentTime = InvokeRetDouble("nkAudioBaseContext.GetCurrentTime");
+                return currentTime;
+            }
+        }
+
         public AudioDestinationNode Destination
         {
             get

--- a/Wasm.Audio/wwwroot/js/Audio.8.0.11.js
+++ b/Wasm.Audio/wwwroot/js/Audio.8.0.11.js
@@ -294,6 +294,17 @@ window.nkAudioBufferSourceNode =
         var bs = nkJSObject.GetObject(uid);
         var pr = bs.playbackRate;
         return nkJSObject.RegisterObject(pr);
+    },
+    Start: function (uid, d)
+    {
+        var bs = nkJSObject.GetObject(uid);
+        var wh = Module.HEAPF64[(d+ 0) >> 3];
+        var os = Module.HEAPF64[(d+ 8) >> 3];
+        var du = Module.HEAPF64[(d+ 16) >> 3];
+        if (du > 0)
+            bs.start(wh, os, du);
+        else
+            bs.start(wh, os);
     }
 };
 

--- a/Wasm.Audio/wwwroot/js/Audio.8.0.11.js
+++ b/Wasm.Audio/wwwroot/js/Audio.8.0.11.js
@@ -189,6 +189,12 @@ window.nkAudioBuffer =
         var ln = ab.length;
         return ln;
     },
+    GetDuration: function (uid, d)
+    {
+        var ab = nkJSObject.GetObject(uid);
+        var du = ab.duration;
+        return du;
+    },
     GetNumberOfChannels: function(uid, d)
     {
         var ab = nkJSObject.GetObject(uid);

--- a/Wasm.Audio/wwwroot/js/Audio.8.0.11.js
+++ b/Wasm.Audio/wwwroot/js/Audio.8.0.11.js
@@ -63,6 +63,12 @@ window.nkAudioBaseContext =
         var sr = ac.sampleRate;
         return sr;
     },
+    GetCurrentTime: function (uid, d)
+    {
+        var ac = nkJSObject.GetObject(uid);
+        var ct = ac.currentTime;
+        return ct;
+    },
     GetDestination: function(uid, d)
     {
         var ac = nkJSObject.GetObject(uid);

--- a/Wasm.Audio/wwwroot/js/Audio.8.0.11.js
+++ b/Wasm.Audio/wwwroot/js/Audio.8.0.11.js
@@ -2,7 +2,7 @@
 {
     Create: function()
     {
-        var ac = new AudioContext();         
+        var ac = new AudioContext();
         return nkJSObject.RegisterObject(ac);
     },
     Create1: function(sampleRate)
@@ -63,7 +63,7 @@ window.nkAudioBaseContext =
         var sr = ac.sampleRate;
         return sr;
     },
-    GetCurrentTime: function (uid, d)
+    GetCurrentTime: function(uid, d)
     {
         var ac = nkJSObject.GetObject(uid);
         var ct = ac.currentTime;
@@ -189,7 +189,7 @@ window.nkAudioBuffer =
         var ln = ab.length;
         return ln;
     },
-    GetDuration: function (uid, d)
+    GetDuration: function(uid, d)
     {
         var ab = nkJSObject.GetObject(uid);
         var du = ab.duration;
@@ -301,7 +301,7 @@ window.nkAudioBufferSourceNode =
         var pr = bs.playbackRate;
         return nkJSObject.RegisterObject(pr);
     },
-    Start: function (uid, d)
+    Start: function(uid, d)
     {
         var bs = nkJSObject.GetObject(uid);
         var wh = Module.HEAPF64[(d+ 0) >> 3];


### PR DESCRIPTION
Adds `BaseAudioContext.CurrentTime`, `AudioBufferSourceNode.Start` and `AudioBuffer.Duration`.

As WebAudio doesn't provide pause/resume at a per sound effect level, these additions are required for implementing pause/resume features. The playback position can be tracked by accumulating the change in `BaseAudioContext.CurrentTime`, resetting for looped sounds after `AudioBuffer.Duration` is reached. The playback position can then be used to resume with `AudioBufferSourceNode.Start` by playing a new sound instance with the start position offset.