### PR TITLE
Adds WebAudio AudioWorkletNodeOptions

### DIFF
--- a/Wasm.Audio/Audio/AudioWorkletNodeOptions.cs
+++ b/Wasm.Audio/Audio/AudioWorkletNodeOptions.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace nkast.Wasm.Audio
+{
+    public struct AudioWorkletNodeOptions
+    {
+        public int? NumberOfInputs;
+        public int? NumberOfOutputs;
+        public int[] OutputChannelCount;
+    }
+}

--- a/Wasm.Audio/Audio/BaseAudioContext.cs
+++ b/Wasm.Audio/Audio/BaseAudioContext.cs
@@ -104,9 +104,13 @@ namespace nkast.Wasm.Audio
             return new StereoPannerNode(uid, this);
         }
 
-        public AudioWorkletNode CreateWorklet(string name)
+        public AudioWorkletNode CreateWorklet(string name, AudioWorkletNodeOptions? options = null)
         {
-            int uid = InvokeRetInt("nkAudioBaseContext.CreateWorklet", name);
+            int numberOfInputs = options?.NumberOfInputs ?? -1;
+            int numberOfOutputs = options?.NumberOfOutputs ?? -1;
+            int[] outputChannelCount = options?.OutputChannelCount ?? new int[0];
+
+            int uid = InvokeRetInt("nkAudioBaseContext.CreateWorklet", name, numberOfInputs, numberOfOutputs, outputChannelCount, outputChannelCount.Length);
             return new AudioWorkletNode(uid, this);
         }
 

--- a/Wasm.Audio/wwwroot/js/Audio.8.0.11.js
+++ b/Wasm.Audio/wwwroot/js/Audio.8.0.11.js
@@ -149,9 +149,23 @@ window.nkAudioBaseContext =
         var module = Module;
         var ac = nkJSObject.GetObject(uid);
         var na = nkJSObject.ReadString(module, d+ 0);
+        var ni = module.HEAP32[(d+ 4)>>2];
+        var no = module.HEAP32[(d+ 8)>>2];
+        var arr = module.HEAP32[(d+ 12)>>2];
+        var cn = module.HEAP32[(d+ 16)>>2];
 
-        var wn = new AudioWorkletNode(ac, na);
+        var arrPtr = Blazor.platform.getArrayEntryPtr(arr, 0, 4);
+        var oc = new Uint32Array(module.HEAPU8.buffer, arrPtr, cn);
 
+        var options = {};
+        if (ni >= 0)
+            options.numberOfInputs = ni;
+        if (no >= 0)
+            options.numberOfOutputs = no;
+        if (cn > 0)
+            options.outputChannelCount = oc;
+
+        var wn = new AudioWorkletNode(ac, na, options);
         return nkJSObject.RegisterObject(wn);
     }
 };


### PR DESCRIPTION
Adds WebAudio AudioWorkletNodeOptions support.

This will allow Kni.BlazorGL to implement stereo channel support for `DynamicSoundEffectInstance`.