### PR TITLE
Adds WebGL texture parameters for sampling

### DIFF
--- a/Wasm.Canvas/Canvas/WebGL/IWebGLRenderingContext.cs
+++ b/Wasm.Canvas/Canvas/WebGL/IWebGLRenderingContext.cs
@@ -53,6 +53,7 @@ namespace nkast.Wasm.Canvas.WebGL
         void ReadPixels<TData>(int x, int y, int width, int height, WebGLFormat format, WebGLTexelType type, TData[] pixels) where TData : struct;
         void ReadPixels<TData>(int x, int y, int width, int height, WebGLFormat format, WebGLTexelType type, TData[] pixels, int index, int count) where TData : struct;
         void TexParameter(WebGLTextureTarget target, WebGLTexParamName pname, WebGLTexParam param);
+        void TexParameter(WebGLTextureTarget target, WebGLTexParamName pname, float param);
         void PixelStore(WebGLPixelParameter pname, int param);
         void BindTexture(WebGLTextureTarget target, WebGLTexture texture);
         void BindBuffer(WebGLBufferType type, WebGLBuffer buffer);

--- a/Wasm.Canvas/Canvas/WebGL/WebGLPName.cs
+++ b/Wasm.Canvas/Canvas/WebGL/WebGLPName.cs
@@ -5,13 +5,15 @@
         MAX_TEXTURE_IMAGE_UNITS          = 0x8872,
         MAX_VERTEX_TEXTURE_IMAGE_UNITS   = 0x8B4C,
         MAX_COMBINED_TEXTURE_IMAGE_UNITS = 0x8B4D,
-        MAX_VERTEX_ATTRIBS           = 0x8869,
-        MAX_TEXTURE_SIZE             = 0x0D33,
-        MAX_CUBE_MAP_TEXTURE_SIZE    = 0x851C,
-        MAX_FRAGMENT_UNIFORM_VECTORS = 0x8DFD,
-        MAX_RENDERBUFFER_SIZE        = 0x84E8,
-        MAX_VARYING_VECTORS          = 0x8DFC,
-        MAX_VERTEX_UNIFORM_VECTORS   = 0x8DFB,
+        MAX_VERTEX_ATTRIBS               = 0x8869,
+        MAX_TEXTURE_SIZE                 = 0x0D33,
+        MAX_CUBE_MAP_TEXTURE_SIZE        = 0x851C,
+        MAX_FRAGMENT_UNIFORM_VECTORS     = 0x8DFD,
+        MAX_RENDERBUFFER_SIZE            = 0x84E8,
+        MAX_VARYING_VECTORS              = 0x8DFC,
+        MAX_VERTEX_UNIFORM_VECTORS       = 0x8DFB,
+
+        MAX_TEXTURE_MAX_ANISOTROPY_EXT   = 0x84FF,
     }
 
     public enum WebGLPNameString

--- a/Wasm.Canvas/Canvas/WebGL/WebGLRenderingContext.cs
+++ b/Wasm.Canvas/Canvas/WebGL/WebGLRenderingContext.cs
@@ -272,6 +272,11 @@ namespace nkast.Wasm.Canvas.WebGL
             Invoke("nkCanvasGLContext.TexParameteri", (int)target, (int)pname, (int)param);
         }
 
+        public void TexParameter(WebGLTextureTarget target, WebGLTexParamName pname, float param)
+        {
+            Invoke("nkCanvasGLContext.TexParameterf", (int)target, (int)pname, param);
+        }
+
         public void PixelStore(WebGLPixelParameter pname, int param)
         {
             Invoke("nkCanvasGLContext.PixelStorei", (int)pname, param);

--- a/Wasm.Canvas/Canvas/WebGL/WebGLTexParam.cs
+++ b/Wasm.Canvas/Canvas/WebGL/WebGLTexParam.cs
@@ -4,10 +4,12 @@ namespace nkast.Wasm.Canvas.WebGL
 {
     public enum WebGLTexParamName
     {
-        TEXTURE_MAG_FILTER      = 0x2800,
-        TEXTURE_MIN_FILTER      = 0x2801,
-        TEXTURE_WRAP_S          = 0x2802,
-        TEXTURE_WRAP_T          = 0x2803,
+        TEXTURE_MAG_FILTER         = 0x2800,
+        TEXTURE_MIN_FILTER         = 0x2801,
+        TEXTURE_WRAP_S             = 0x2802,
+        TEXTURE_WRAP_T             = 0x2803,
+
+        TEXTURE_MAX_ANISOTROPY_EXT = 0x84FE,
     }
 
     public enum WebGLTexParam

--- a/Wasm.Canvas/Canvas/WebGL/WebGLTexParam.cs
+++ b/Wasm.Canvas/Canvas/WebGL/WebGLTexParam.cs
@@ -10,6 +10,11 @@ namespace nkast.Wasm.Canvas.WebGL
         TEXTURE_WRAP_T             = 0x2803,
 
         TEXTURE_MAX_ANISOTROPY_EXT = 0x84FE,
+
+        // WebGL2
+        TEXTURE_WRAP_R             = 0x8072,
+        TEXTURE_MIN_LOD            = 0x813A,
+        TEXTURE_MAX_LOD            = 0x813B,
     }
 
     public enum WebGLTexParam

--- a/Wasm.Canvas/wwwroot/js/CanvasGLContext.10.0.0.js
+++ b/Wasm.Canvas/wwwroot/js/CanvasGLContext.10.0.0.js
@@ -701,6 +701,15 @@ window.nkCanvasGLContext =
         gc.texParameteri(tg, pn, pm);
     },
 
+    TexParameterf: function (uid, module, d)
+    {
+        var gc = nkJSObject.GetObject(uid);
+        var tg = module.HEAP32[(d+ 0)>>2];
+        var pn = module.HEAP32[(d+ 4)>>2];
+        var pm = module.HEAPF32[(d+ 8)>>2];
+        gc.texParameterf(tg, pn, pm);
+    },
+
     PixelStorei: function(uid, module, d)
     {
         var gc = nkJSObject.GetObject(uid);


### PR DESCRIPTION
Adds additional `WebGLTexParamName` and `WebGLPNameInteger` enum values. Also adds `WebGLRenderingContext.TexParameter` method for setting float values (the previous method only accepted fixed enum values). 

These additions will allow Kni.BlazorGL to implement `SamplerState` functionality including anisotropy filtering, min/max mip levels and Texture3D wrapping.