### PR TITLE
Adds additional WebGL TexImage2D methods

### DIFF
--- a/Wasm.Canvas/Canvas/WebGL/IWebGLRenderingContext.cs
+++ b/Wasm.Canvas/Canvas/WebGL/IWebGLRenderingContext.cs
@@ -52,6 +52,8 @@ namespace nkast.Wasm.Canvas.WebGL
         void TexSubImage2D<TData>(WebGLTextureTarget target, int level, int xoffset, int yoffset, int width, int height, WebGLFormat format, WebGLTexelType type, TData[] pixels, int index, int count) where TData : struct;
         void CompressedTexImage2D<TData>(WebGLTextureTarget target, int level, WebGLInternalFormat internalFormat, int width, int height, TData[] pixels) where TData : struct;
         void CompressedTexImage2D<TData>(WebGLTextureTarget target, int level, WebGLInternalFormat internalFormat, int width, int height, TData[] pixels, int index, int count) where TData : struct;
+        void CompressedTexSubImage2D<TData>(WebGLTextureTarget target, int level, int xoffset, int yoffset, int width, int height, WebGLFormat format, TData[] pixels) where TData : struct;
+        void CompressedTexSubImage2D<TData>(WebGLTextureTarget target, int level, int xoffset, int yoffset, int width, int height, WebGLFormat format, TData[] pixels, int index, int count) where TData : struct;
         void ReadPixels<TData>(int x, int y, int width, int height, WebGLFormat format, WebGLTexelType type, TData[] pixels) where TData : struct;
         void ReadPixels<TData>(int x, int y, int width, int height, WebGLFormat format, WebGLTexelType type, TData[] pixels, int index, int count) where TData : struct;
         void TexParameter(WebGLTextureTarget target, WebGLTexParamName pname, WebGLTexParam param);

--- a/Wasm.Canvas/Canvas/WebGL/IWebGLRenderingContext.cs
+++ b/Wasm.Canvas/Canvas/WebGL/IWebGLRenderingContext.cs
@@ -49,6 +49,7 @@ namespace nkast.Wasm.Canvas.WebGL
         void TexImage2D<TData>(WebGLTextureTarget target, int level, WebGLInternalFormat internalFormat, int width, int height, WebGLFormat format, WebGLTexelType type, TData[] pixels, int index, int count) where TData : struct;
         void TexImage2D(WebGLTextureTarget target, int level, WebGLInternalFormat internalFormat, WebGLFormat format, WebGLTexelType type, Video video);
         void TexSubImage2D<TData>(WebGLTextureTarget target, int level, int xoffset, int yoffset, int width, int height, WebGLFormat format, WebGLTexelType type, TData[] pixels) where TData : struct;
+        void TexSubImage2D<TData>(WebGLTextureTarget target, int level, int xoffset, int yoffset, int width, int height, WebGLFormat format, WebGLTexelType type, TData[] pixels, int index, int count) where TData : struct;
         void CompressedTexImage2D<TData>(WebGLTextureTarget target, int level, WebGLInternalFormat internalFormat, int width, int height, TData[] pixels) where TData : struct;
         void CompressedTexImage2D<TData>(WebGLTextureTarget target, int level, WebGLInternalFormat internalFormat, int width, int height, TData[] pixels, int index, int count) where TData : struct;
         void ReadPixels<TData>(int x, int y, int width, int height, WebGLFormat format, WebGLTexelType type, TData[] pixels) where TData : struct;

--- a/Wasm.Canvas/Canvas/WebGL/IWebGLRenderingContext.cs
+++ b/Wasm.Canvas/Canvas/WebGL/IWebGLRenderingContext.cs
@@ -46,6 +46,7 @@ namespace nkast.Wasm.Canvas.WebGL
         bool GetProgramParameter(WebGLProgram program, WebGLProgramStatus pname);
         void TexImage2D(WebGLTextureTarget target, int level, WebGLInternalFormat internalFormat, int width, int height, WebGLFormat format, WebGLTexelType type);
         void TexImage2D<TData>(WebGLTextureTarget target, int level, WebGLInternalFormat internalFormat, int width, int height, WebGLFormat format, WebGLTexelType type, TData[] pixels) where TData : struct;
+        void TexImage2D<TData>(WebGLTextureTarget target, int level, WebGLInternalFormat internalFormat, int width, int height, WebGLFormat format, WebGLTexelType type, TData[] pixels, int index, int count) where TData : struct;
         void TexImage2D(WebGLTextureTarget target, int level, WebGLInternalFormat internalFormat, WebGLFormat format, WebGLTexelType type, Video video);
         void TexSubImage2D<TData>(WebGLTextureTarget target, int level, int xoffset, int yoffset, int width, int height, WebGLFormat format, WebGLTexelType type, TData[] pixels) where TData : struct;
         void CompressedTexImage2D<TData>(WebGLTextureTarget target, int level, WebGLInternalFormat internalFormat, int width, int height, TData[] pixels) where TData : struct;

--- a/Wasm.Canvas/Canvas/WebGL/WebGLRenderingContext.cs
+++ b/Wasm.Canvas/Canvas/WebGL/WebGLRenderingContext.cs
@@ -246,6 +246,14 @@ namespace nkast.Wasm.Canvas.WebGL
             Invoke("nkCanvasGLContext.TexSubImage2D1", (int)target, level, position, width, height, (int)format, (int)type, stride, pixels, pixels.Length);
         }
 
+        public void TexSubImage2D<TData>(WebGLTextureTarget target, int level, int xoffset, int yoffset, int width, int height, WebGLFormat format, WebGLTexelType type, TData[] pixels, int index, int count)
+            where TData : struct
+        {
+            var stride = Marshal.SizeOf<TData>();
+            var position = ValueTuple.Create<int, int>(xoffset, yoffset);
+            Invoke("nkCanvasGLContext.TexSubImage2D2", (int)target, level, position, width, height, (int)format, (int)type, stride, pixels, index, count);
+        }
+
         public void CompressedTexImage2D<TData>(WebGLTextureTarget target, int level, WebGLInternalFormat internalFormat, int width, int height, TData[] pixels)
             where TData : struct
         {

--- a/Wasm.Canvas/Canvas/WebGL/WebGLRenderingContext.cs
+++ b/Wasm.Canvas/Canvas/WebGL/WebGLRenderingContext.cs
@@ -226,6 +226,13 @@ namespace nkast.Wasm.Canvas.WebGL
             Invoke("nkCanvasGLContext.TexImage2D1", (int)target, level, (int)internalFormat, width, height, (int)format, (int)type, stride, pixels, pixels.Length);
         }
 
+        public void TexImage2D<TData>(WebGLTextureTarget target, int level, WebGLInternalFormat internalFormat, int width, int height, WebGLFormat format, WebGLTexelType type, TData[] pixels, int index, int count)
+            where TData : struct
+        {
+            var stride = Marshal.SizeOf<TData>();
+            Invoke("nkCanvasGLContext.TexImage2D3", (int)target, level, (int)internalFormat, width, height, (int)format, (int)type, stride, pixels, index, count);
+        }
+
         public void TexImage2D(WebGLTextureTarget target, int level, WebGLInternalFormat internalFormat, WebGLFormat format, WebGLTexelType type, Video video)
         {
             Invoke("nkCanvasGLContext.TexImage2D2", (int)target, level, (int)internalFormat,  (int)format, (int)type, video.Uid);

--- a/Wasm.Canvas/Canvas/WebGL/WebGLRenderingContext.cs
+++ b/Wasm.Canvas/Canvas/WebGL/WebGLRenderingContext.cs
@@ -268,6 +268,22 @@ namespace nkast.Wasm.Canvas.WebGL
             Invoke("nkCanvasGLContext.CompressedTexImage2D", (int)target, level, (int)internalFormat, width, height, stride, pixels, index, count);
         }
 
+        public void CompressedTexSubImage2D<TData>(WebGLTextureTarget target, int level, int xoffset, int yoffset, int width, int height, WebGLFormat format, TData[] pixels)
+            where TData : struct
+        {
+            var stride = Marshal.SizeOf<TData>();
+            var position = ValueTuple.Create<int, int>(xoffset, yoffset);
+            Invoke("nkCanvasGLContext.CompressedTexSubImage2D", (int)target, level, position, width, height, (int)format, stride, pixels, 0, pixels.Length);
+        }
+
+        public void CompressedTexSubImage2D<TData>(WebGLTextureTarget target, int level, int xoffset, int yoffset, int width, int height, WebGLFormat format, TData[] pixels, int index, int count)
+            where TData : struct
+        {
+            var stride = Marshal.SizeOf<TData>();
+            var position = ValueTuple.Create<int, int>(xoffset, yoffset);
+            Invoke("nkCanvasGLContext.CompressedTexSubImage2D", (int)target, level, position, width, height, (int)format, stride, pixels, index, count);
+        }
+
         public void ReadPixels<TData>(int x, int y, int width, int height, WebGLFormat format, WebGLTexelType type, TData[] pixels)
             where TData : struct
         {

--- a/Wasm.Canvas/wwwroot/js/CanvasGLContext.10.0.0.js
+++ b/Wasm.Canvas/wwwroot/js/CanvasGLContext.10.0.0.js
@@ -632,6 +632,27 @@ window.nkCanvasGLContext =
         gc.texImage2D(tg, lv, it, ft, tp, vi);
     },
 
+    TexImage2D3: function (uid, module, d)
+    {
+        var gc = nkJSObject.GetObject(uid);
+        var tg = module.HEAP32[(d+ 0)>>2];
+        var lv = module.HEAP32[(d+ 4)>>2];
+        var it = module.HEAP32[(d+ 8)>>2];
+        var wh = module.HEAP32[(d+12)>>2];
+        var ht = module.HEAP32[(d+16)>>2];
+        var ft = module.HEAP32[(d+20)>>2];
+        var tp = module.HEAP32[(d+24)>>2];
+        var st = module.HEAP32[(d+28)>>2];
+        var arr = module.HEAP32[(d+32)>>2];
+        var ix = module.HEAP32[(d+36)>>2];
+        var ot = module.HEAP32[(d+40)>>2];
+
+        var arrPtr = Blazor.platform.getArrayEntryPtr(arr, 0, 4);
+        var dt = new Uint8Array(module.HEAPU8.buffer, arrPtr + ix * st, ot * st);
+
+        gc.texImage2D(tg, lv, it, wh, ht, 0, ft, tp, dt);
+    },
+
     TexSubImage2D1: function(uid, module, d)
     {
         var gc = nkJSObject.GetObject(uid);

--- a/Wasm.Canvas/wwwroot/js/CanvasGLContext.10.0.0.js
+++ b/Wasm.Canvas/wwwroot/js/CanvasGLContext.10.0.0.js
@@ -673,7 +673,29 @@ window.nkCanvasGLContext =
 
         gc.texSubImage2D(tg, lv, xo, yo, wh, ht, ft, tp, dt);
     },
-  
+
+    TexSubImage2D2: function (uid, module, d)
+    {
+        var gc = nkJSObject.GetObject(uid);
+        var tg = module.HEAP32[(d+ 0)>>2];
+        var lv = module.HEAP32[(d+ 4)>>2];
+        var xo = module.HEAP32[(d+ 8)>>2];
+        var yo = module.HEAP32[(d+12)>>2];
+        var wh = module.HEAP32[(d+16)>>2];
+        var ht = module.HEAP32[(d+20)>>2];
+        var ft = module.HEAP32[(d+24)>>2];
+        var tp = module.HEAP32[(d+28)>>2];
+        var st = module.HEAP32[(d+32)>>2];
+        var arr = module.HEAP32[(d+36)>>2];
+        var ix = module.HEAP32[(d+40)>>2];
+        var ot = module.HEAP32[(d+44)>>2];
+
+        var arrPtr = Blazor.platform.getArrayEntryPtr(arr, 0, 4);
+        var dt = new Uint8Array(module.HEAPU8.buffer, arrPtr + ix * st, ot * st);
+
+        gc.texSubImage2D(tg, lv, xo, yo, wh, ht, ft, tp, dt);
+    },
+
     CompressedTexImage2D: function(uid, module, d)
     {
         var gc = nkJSObject.GetObject(uid);

--- a/Wasm.Canvas/wwwroot/js/CanvasGLContext.10.0.0.js
+++ b/Wasm.Canvas/wwwroot/js/CanvasGLContext.10.0.0.js
@@ -715,6 +715,27 @@ window.nkCanvasGLContext =
         gc.compressedTexImage2D(tg, lv, it, wh, ht, 0, dt);
     },
 
+    CompressedTexSubImage2D: function (uid, module, d)
+    {
+        var gc = nkJSObject.GetObject(uid);
+        var tg = module.HEAP32[(d+ 0)>>2];
+        var lv = module.HEAP32[(d+ 4)>>2];
+        var xo = module.HEAP32[(d+ 8)>>2];
+        var yo = module.HEAP32[(d+12)>>2];
+        var wh = module.HEAP32[(d+16)>>2];
+        var ht = module.HEAP32[(d+20)>>2];
+        var ft = module.HEAP32[(d+24)>>2];
+        var st = module.HEAP32[(d+28)>>2];
+        var arr = module.HEAP32[(d+32)>>2];
+        var ix = module.HEAP32[(d+36)>>2];
+        var ot = module.HEAP32[(d+40)>>2];
+
+        var arrPtr = Blazor.platform.getArrayEntryPtr(arr, 0, 4);
+        var dt = new Uint8Array(module.HEAPU8.buffer, arrPtr + ix * st, ot * st);
+
+        gc.compressedTexSubImage2D(tg, lv, xo, yo, wh, ht, ft, dt);
+    },
+
     ReadPixels: function(uid, module, d)
     {
         var gc = nkJSObject.GetObject(uid);

--- a/Wasm.JSInterop/JSInterop/JSObject.Invoke.cs
+++ b/Wasm.JSInterop/JSInterop/JSObject.Invoke.cs
@@ -467,6 +467,76 @@ namespace nkast.Wasm.JSInterop
             var args = new FixedStructA<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA>(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, argA);
             return JSInvoke2String(fid, Uid, (int)&args);
         }
+
+        protected unsafe void Invoke<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB>(string identifier, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, TA argA, TB argB)
+        {
+            int fid = RegisterFunction(identifier);
+            var args = new FixedStructB<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB>(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, argA, argB);
+            JSInvoke2Void(fid, Uid, (int)&args);
+        }
+
+        protected unsafe bool InvokeRetBool<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB>(string identifier, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, TA argA, TB argB)
+        {
+            int fid = RegisterFunction(identifier);
+            var args = new FixedStructB<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB>(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, argA, argB);
+            return JSInvoke2Bool(fid, Uid, (int)&args);
+        }
+
+        protected unsafe int InvokeRetInt<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB>(string identifier, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, TA argA, TB argB)
+        {
+            int fid = RegisterFunction(identifier);
+            var args = new FixedStructB<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB>(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, argA, argB);
+            return JSInvoke2Int(fid, Uid, (int)&args);
+        }
+
+        protected unsafe float InvokeRetFloat<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB>(string identifier, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, TA argA, TB argB)
+        {
+            int fid = RegisterFunction(identifier);
+            var args = new FixedStructB<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB>(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, argA, argB);
+            return JSInvoke2Float(fid, Uid, (int)&args);
+        }
+
+        protected unsafe string InvokeRetString<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB>(string identifier, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, TA argA, TB argB)
+        {
+            int fid = RegisterFunction(identifier);
+            var args = new FixedStructB<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB>(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, argA, argB);
+            return JSInvoke2String(fid, Uid, (int)&args);
+        }
+
+        protected unsafe void Invoke<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB, TC>(string identifier, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, TA argA, TB argB, TC argC)
+        {
+            int fid = RegisterFunction(identifier);
+            var args = new FixedStructC<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB, TC>(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, argA, argB, argC);
+            JSInvoke2Void(fid, Uid, (int)&args);
+        }
+
+        protected unsafe bool InvokeRetBool<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB, TC>(string identifier, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, TA argA, TB argB, TC argC)
+        {
+            int fid = RegisterFunction(identifier);
+            var args = new FixedStructC<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB, TC>(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, argA, argB, argC);
+            return JSInvoke2Bool(fid, Uid, (int)&args);
+        }
+
+        protected unsafe int InvokeRetInt<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB, TC>(string identifier, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, TA argA, TB argB, TC argC)
+        {
+            int fid = RegisterFunction(identifier);
+            var args = new FixedStructC<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB, TC>(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, argA, argB, argC);
+            return JSInvoke2Int(fid, Uid, (int)&args);
+        }
+
+        protected unsafe float InvokeRetFloat<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB, TC>(string identifier, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, TA argA, TB argB, TC argC)
+        {
+            int fid = RegisterFunction(identifier);
+            var args = new FixedStructC<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB, TC>(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, argA, argB, argC);
+            return JSInvoke2Float(fid, Uid, (int)&args);
+        }
+
+        protected unsafe string InvokeRetString<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB, TC>(string identifier, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, TA argA, TB argB, TC argC)
+        {
+            int fid = RegisterFunction(identifier);
+            var args = new FixedStructC<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB, TC>(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, argA, argB, argC);
+            return JSInvoke2String(fid, Uid, (int)&args);
+        }
     }
 
     internal struct FixedStruct8<T1, T2, T3, T4, T5, T6, T7, T8>
@@ -544,6 +614,68 @@ namespace nkast.Wasm.JSInterop
             Value8 = value8;
             Value9 = value9;
             ValueA = valueA;
+        }
+    }
+
+    internal struct FixedStructB<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB>
+    {
+        public readonly T1 Value1;
+        public readonly T2 Value2;
+        public readonly T3 Value3;
+        public readonly T4 Value4;
+        public readonly T5 Value5;
+        public readonly T6 Value6;
+        public readonly T7 Value7;
+        public readonly T8 Value8;
+        public readonly T9 Value9;
+        public readonly TA ValueA;
+        public readonly TB ValueB;
+
+        public FixedStructB(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, TA valueA, TB valueB) : this()
+        {
+            Value1 = value1;
+            Value2 = value2;
+            Value3 = value3;
+            Value4 = value4;
+            Value5 = value5;
+            Value6 = value6;
+            Value7 = value7;
+            Value8 = value8;
+            Value9 = value9;
+            ValueA = valueA;
+            ValueB = valueB;
+        }
+    }
+
+    internal struct FixedStructC<T1, T2, T3, T4, T5, T6, T7, T8, T9, TA, TB, TC>
+    {
+        public readonly T1 Value1;
+        public readonly T2 Value2;
+        public readonly T3 Value3;
+        public readonly T4 Value4;
+        public readonly T5 Value5;
+        public readonly T6 Value6;
+        public readonly T7 Value7;
+        public readonly T8 Value8;
+        public readonly T9 Value9;
+        public readonly TA ValueA;
+        public readonly TB ValueB;
+        public readonly TC ValueC;
+
+        public FixedStructC(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, TA valueA, TB valueB, TC valueC) : this()
+        {
+            Value1 = value1;
+            Value2 = value2;
+            Value3 = value3;
+            Value4 = value4;
+            Value5 = value5;
+            Value6 = value6;
+            Value7 = value7;
+            Value8 = value8;
+            Value9 = value9;
+            ValueA = valueA;
+            ValueB = valueB;
+            ValueC = valueC;
         }
     }
 }


### PR DESCRIPTION
Adds additional WebGL TexImage2D methods for specifying index & count and also retrieving sub regions for compressed textures. Also adds support for 11 & 12 arguments with `JSObject.Invoke` methods.

These additions will allow Kni.BlazorGL to implement remaining `Texture2D` and `TextureCube` methods.