### PR TITLE
Adds WebGL FramebufferTexture methods

### DIFF
--- a/Wasm.Canvas/Canvas/WebGL/IWebGLRenderingContext.cs
+++ b/Wasm.Canvas/Canvas/WebGL/IWebGLRenderingContext.cs
@@ -60,6 +60,7 @@ namespace nkast.Wasm.Canvas.WebGL
         void BindRenderbuffer(WebGLRenderbufferType target, WebGLRenderbuffer renderbuffer);
         void FramebufferRenderbuffer(WebGLFramebufferType target, WebGLFramebufferAttachmentPoint attachment, WebGLRenderbufferType renderbuffertarget, WebGLRenderbuffer renderbuffer);
         void FramebufferTexture2D(WebGLFramebufferType target, WebGLFramebufferAttachmentPoint attachment, WebGLTextureTarget texturetarget, WebGLTexture texture);
+        void FramebufferTexture2D(WebGLFramebufferType target, WebGLFramebufferAttachmentPoint attachment, WebGLTextureTarget texturetarget, WebGLTexture texture, int level);
         void RenderbufferStorage(WebGLRenderbufferType target, WebGLRenderbufferInternalFormat internalFormat, int width, int height);
         WebGLFramebufferStatus CheckFramebufferStatus(WebGLFramebufferType target);
         void GenerateMipmap(WebGLTextureTarget target);

--- a/Wasm.Canvas/Canvas/WebGL/WebGLRenderingContext.cs
+++ b/Wasm.Canvas/Canvas/WebGL/WebGLRenderingContext.cs
@@ -310,6 +310,11 @@ namespace nkast.Wasm.Canvas.WebGL
             Invoke("nkCanvasGLContext.FramebufferTexture2D", (int)target, (int)attachment, (int)texturetarget, texture.Uid);
         }
 
+        public void FramebufferTexture2D(WebGLFramebufferType target, WebGLFramebufferAttachmentPoint attachment, WebGLTextureTarget texturetarget, WebGLTexture texture, int level)
+        {
+            Invoke("nkCanvasGLContext.FramebufferTexture2D1", (int)target, (int)attachment, (int)texturetarget, texture.Uid, level);
+        }
+
         public void RenderbufferStorage(WebGLRenderbufferType target, WebGLRenderbufferInternalFormat internalFormat, int width, int height)
         {
             Invoke("nkCanvasGLContext.RenderbufferStorage", (int)target, (int)internalFormat, width, height);

--- a/Wasm.Canvas/Canvas/WebGL2/IWebGL2RenderingContext.cs
+++ b/Wasm.Canvas/Canvas/WebGL2/IWebGL2RenderingContext.cs
@@ -13,6 +13,7 @@ namespace nkast.Wasm.Canvas.WebGL
         void InvalidateFramebuffer(WebGL2FramebufferType target, WebGLFramebufferAttachmentPoint[] attachments);
         void InvalidateFramebuffer(WebGL2FramebufferType target, WebGLFramebufferAttachmentPoint[] attachments, int startIndex, int length);
         void BlitFramebuffer(int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, WebGLBufferBits mask, WebGLTexParam filter);
+        void FramebufferTextureLayer(WebGL2FramebufferType target, WebGLFramebufferAttachmentPoint attachment, WebGLTexture texture, int level, int layer);
         void ReadBuffer(WebGL2DrawBufferAttachmentPoint buffer);
         void DrawBuffer(WebGL2DrawBufferAttachmentPoint buffer);
         void DrawBuffers(WebGL2DrawBufferAttachmentPoint[] buffers);

--- a/Wasm.Canvas/Canvas/WebGL2/WebGL2RenderingContext.cs
+++ b/Wasm.Canvas/Canvas/WebGL2/WebGL2RenderingContext.cs
@@ -48,6 +48,12 @@ namespace nkast.Wasm.Canvas.WebGL
                                                          (int)mask, (int)filter);
         }
 
+        public void FramebufferTextureLayer(WebGL2FramebufferType target, WebGLFramebufferAttachmentPoint attachment, WebGLTexture texture, int level, int layer)
+        {
+            int uid = (texture != null) ? texture.Uid : -1;
+            Invoke("nkCanvasGL2Context.FramebufferTextureLayer", (int)target, attachment, uid, level, layer);
+        }
+
         public void ReadBuffer(WebGL2DrawBufferAttachmentPoint buffer)
         {
             Invoke("nkCanvasGL2Context.ReadBuffer", (int) buffer);

--- a/Wasm.Canvas/wwwroot/js/CanvasGLContext.10.0.0.js
+++ b/Wasm.Canvas/wwwroot/js/CanvasGLContext.10.0.0.js
@@ -768,6 +768,18 @@ window.nkCanvasGLContext =
         gc.framebufferTexture2D(ft, ap, tt, tb, lv);
     },
 
+    FramebufferTexture2D1: function (uid, module, d)
+    {
+        var gc = nkJSObject.GetObject(uid);
+        var ft = module.HEAP32[(d+ 0)>>2];
+        var ap = module.HEAP32[(d+ 4)>>2];
+        var tt = module.HEAP32[(d+ 8)>>2];
+        var tbuid = module.HEAP32[(d+12)>>2];
+        var tb = nkJSObject.GetObject(tbuid);
+        var lv = module.HEAP32[(d+16)>>2];
+        gc.framebufferTexture2D(ft, ap, tt, tb, lv);
+    },
+
     RenderbufferStorage: function(uid, module, d)
     {
         var gc = nkJSObject.GetObject(uid);

--- a/Wasm.Canvas/wwwroot/js/CanvasGLContext.10.0.0.js
+++ b/Wasm.Canvas/wwwroot/js/CanvasGLContext.10.0.0.js
@@ -1018,7 +1018,19 @@ window.nkCanvasGL2Context =
             sX0, sY0, sX1, sY1,
             dX0, dY0, dX1, dY1,
             mk, fr);
-    },    
+    },
+    FramebufferTextureLayer: function (uid, module, d)
+    {
+        var gc = nkJSObject.GetObject(uid);
+        var ft = module.HEAP32[(d+ 0)>>2];
+        var at = module.HEAP32[(d+ 4)>>2];
+        var txuid = module.HEAP32[(d+ 8) >> 2];
+        var tx = (txuid != -1) ? nkJSObject.GetObject(txuid) : null;
+        var lv = module.HEAP32[(d+12)>>2];
+        var ly = module.HEAP32[(d+16)>>2];
+
+        gc.framebufferTextureLayer(ft, at, tx, lv, ly);
+    },
     ReadBuffer: function(uid, module, d)
     {
         var gc = nkJSObject.GetObject(uid);


### PR DESCRIPTION
Adds an additional WebGL `FramebufferTexture2D` method which includes the mipmap level argument (this is missing from the existing implementation). Also adds a WebGL2 `FramebufferTextureLayer` method for reading data from Texture3D.

These additions will allow Kni.BlazorGL to implement remaining `Texture.GetData` methods.