### PR TITLE
Fix unsafe JS interop call in JSObject finalizer

### DIFF
--- a/Wasm.JSInterop/JSInterop/JSObject.IDisposable.cs
+++ b/Wasm.JSInterop/JSInterop/JSObject.IDisposable.cs
@@ -44,12 +44,10 @@ namespace nkast.Wasm.JSInterop
             {
                 if (disposing)
                 {
-
+                    Invoke("nkJSObject.DisposeObject", Uid);
                 }
-
-                Invoke("nkJSObject.DisposeObject", Uid);
                 Uid = -1;
-
+                // finalizer path: do nothing (avoid JS interop from GC thread)
                 _isDisposed = true;
             }
             else


### PR DESCRIPTION
## Summary

This PR fixes an unsafe disposal behavior in `JSObject`.

Previously, the finalizer called `Dispose(false)`, but `Dispose(false)` still invoked JavaScript interop through:

```csharp
Invoke("nkJSObject.DisposeObject", Uid);
```

Calling JavaScript interop from a finalizer is unsafe because the finalizer runs during garbage collection, outside the normal Blazor/WebAssembly execution flow.

## Problem

The current implementation allows the `JSObject` finalizer to trigger JavaScript interop:

```csharp
~JSObject()
{
    Dispose(false);
}
```

However, `Dispose(false)` still calls into JavaScript:

```csharp
Invoke("nkJSObject.DisposeObject", Uid);
```

This can cause unstable behavior because:

* Finalizers run at an unpredictable time.
* The JavaScript runtime may no longer be in a valid state.
* Blazor/WebAssembly JS interop should not be executed from the GC finalizer path.
* Exceptions thrown during finalization can be difficult to diagnose and may crash the application.

This is especially problematic in Blazor WebAssembly/WebGL scenarios where many JS-backed objects may be created and collected during rendering or game loops.

## Changes

This PR changes the disposal logic so that JavaScript interop is only executed during explicit disposal.

Specifically:

* `Dispose(true)` continues to release the JavaScript-side object.
* `Dispose(false)` no longer invokes JavaScript interop.
* The finalizer no longer performs JS-side cleanup directly.

## Rationale

This aligns the implementation with the standard .NET dispose pattern:

* `Dispose(true)` may release managed resources.
* `Dispose(false)` should avoid accessing managed objects or runtime services.
* Finalizers should not call into external managed runtime infrastructure such as Blazor JS interop.

For `JSObject`, the JavaScript-side object should be released through deterministic disposal by calling `Dispose()`.

## Impact

This change prevents unsafe JavaScript interop calls from the GC finalizer path.

Expected benefits:

* Avoids random runtime errors during garbage collection.
* Improves stability in Blazor WebAssembly applications.
* Reduces the risk of crashes in WebGL/game-loop scenarios.
* Keeps the public API unchanged.

## Compatibility

This PR does not introduce any public API changes.

The only behavior change is that JavaScript-side cleanup is now performed only when `Dispose()` is called explicitly, rather than from the finalizer path.

Code that already disposes `JSObject` instances correctly is unaffected.

